### PR TITLE
Fix typo in Servo library comment

### DIFF
--- a/EMG_control_system/EMG_control_system.ino
+++ b/EMG_control_system/EMG_control_system.ino
@@ -13,7 +13,7 @@
   depending on the EMG values.
  */
 
-  // loading the servo libruary
+  // loading the servo library
 #include <Servo.h>
 Servo myServo2;
 Servo myServo3;


### PR DESCRIPTION
## Summary
- fix typo in servo library inclusion comment

## Testing
- `arduino-cli compile EMG_control_system` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1b53fc2883249297e3d7a598db4a